### PR TITLE
PHPCS/Composer: update PHPCompatibility

### DIFF
--- a/build/phpcomp.xml
+++ b/build/phpcomp.xml
@@ -16,7 +16,6 @@
   -->
 
 <ruleset name="codenamephp">
-  <ini name="date.timezone" value="Europe/Berlin"/>
   <config name="testVersion" value="7.0-"/>
   <rule ref="PHPCompatibility" />
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require-dev": {
     "ext-xdebug": "*",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
     "doctrine/cache": "~1.4",
     "mockery/mockery": "^1.1",
     "pdepend/pdepend": "^2",
@@ -25,7 +25,7 @@
     "phpunit/phpunit": "^7",
     "sebastian/phpcpd": "^4.0",
     "squizlabs/php_codesniffer": "^3.3",
-    "wimg/php-compatibility": "^8.2"
+    "phpcompatibility/php-compatibility": "^9.0"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
Composer:
* `wimg/php-compatibility` has been abandoned for nearly a year. Use `phpcompatibility/php-compatibility` instead.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with the upcoming PHP 7.4.
* Use the latest version of the DealerDirect Composer PHPCS plugin.
    Composer treats minors < 1.0 as majors, so you need to explicitely update.

PHPCS PHPCompatibility ruleset:
* No need to set the `date.timezone`. That sniff has been removed for quite a while now.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases