### PR TITLE
Remove unused symfony/filesystem package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
      uses: actions/cache@v2
      with:
       path: ${{ steps.composer-cache.outputs.dir }}
-      key: ${{ runner.os }}-composer-latest
-      restore-keys: ${{ runner.os }}-composer-latest
+      key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+      restore-keys: |
+       ${{ runner.os }}-composer-
 
    - name: Install dependencies
      if: steps.composer-cache.outputs.cache-hit != 'true'
@@ -59,8 +60,9 @@ jobs:
      uses: actions/cache@v2
      with:
       path: ${{ steps.composer-cache.outputs.dir }}
-      key: ${{ runner.os }}-composer-lowest
-      restore-keys: ${{ runner.os }}-composer-lowest
+      key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+      restore-keys: |
+       ${{ runner.os }}-composer-
 
    - name: Install dependencies
      if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -25,8 +25,6 @@
       <path value="$PROJECT_DIR$/vendor/dealerdirect/phpcodesniffer-composer-installer" />
       <path value="$PROJECT_DIR$/vendor/codenamephp/platform.core" />
       <path value="$PROJECT_DIR$/vendor/squizlabs/php_codesniffer" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-util" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php56" />
       <path value="$PROJECT_DIR$/vendor/php-di/invoker" />
       <path value="$PROJECT_DIR$/vendor/php-di/phpdoc-reader" />
       <path value="$PROJECT_DIR$/vendor/php-di/php-di" />
@@ -35,8 +33,6 @@
       <path value="$PROJECT_DIR$/vendor/composer" />
       <path value="$PROJECT_DIR$/vendor/jeremeamia/superclosure" />
       <path value="$PROJECT_DIR$/vendor/phpcompatibility/php-compatibility" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-ctype" />
-      <path value="$PROJECT_DIR$/vendor/symfony/filesystem" />
       <path value="$PROJECT_DIR$/vendor/opis/closure" />
       <path value="$PROJECT_DIR$/vendor/marcj/topsort" />
     </include_path>

--- a/.idea/platform.di.iml
+++ b/.idea/platform.di.iml
@@ -39,15 +39,6 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/phpunit" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/container" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/squizlabs/php_codesniffer" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/config" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/console" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/dependency-injection" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/filesystem" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/finder" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-ctype" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-mbstring" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php56" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-util" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/fdomdocument" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6 || ^0.7",
     "phpcompatibility/php-compatibility": "^9.0",
-    "squizlabs/php_codesniffer": "^3.5",
-    "symfony/filesystem": "^5.0"
+    "squizlabs/php_codesniffer": "^3.5"
   },
   "autoload": {
     "psr-4": {

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -23,7 +23,6 @@ use de\codenamephp\platform\di\definitionsProvider\iFiles;
 use de\codenamephp\platform\di\definitionsProvider\iMetaProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  *
@@ -38,13 +37,6 @@ final class ContainerBuilderTest extends TestCase {
     $containerBuilder = $this->createMock(\DI\ContainerBuilder::class);
 
     $this->sut = new ContainerBuilder($containerBuilder);
-  }
-
-  protected function tearDown() : void {
-    parent::tearDown();
-
-    $fileSystem = new Filesystem();
-    $fileSystem->remove(__DIR__ . '/tmp');
   }
 
   public function test__construct_canCreateDefaultContainer_ifNoContainerIsGiven() : void {


### PR DESCRIPTION
The symfony/filesystem package was used to clean up a temp folder that contained defintion files for tests. Since the refactoring where the container builder is now a dependency of my own container builder the actual call is mocked so the files are never used. Therefore the tear down and the dependency were removed.