### PR TITLE
Extracted check for added provider for improved readability

### DIFF
--- a/src/definitionsProvider/collection/CreateAndAddDependenciesBeforeProvider.php
+++ b/src/definitionsProvider/collection/CreateAndAddDependenciesBeforeProvider.php
@@ -92,7 +92,7 @@ final class CreateAndAddDependenciesBeforeProvider implements iCollection {
   public function add(iDefinitionsProvider $provider) : iCollection {
     if($provider instanceof iDependsOn) {
       foreach($provider->getDependencies() as $dependencyClassname) {
-        if(!in_array($dependencyClassname, $this->getAddedProviderClassnames(), true)) $this->add($this->getByClassnameProviderFactory()->build($dependencyClassname));
+        if($this->providerWasNotYetAdded($dependencyClassname)) $this->add($this->getByClassnameProviderFactory()->build($dependencyClassname));
       }
     }
 
@@ -102,4 +102,7 @@ final class CreateAndAddDependenciesBeforeProvider implements iCollection {
     return $this;
   }
 
+  private function providerWasNotYetAdded(string $dependencyClassname) : bool {
+    return !in_array($dependencyClassname, $this->getAddedProviderClassnames(), true);
+  }
 }


### PR DESCRIPTION
array_diff would not work since the diff would have to be updated after the recursion. But instead of doing nothing I extracted the check if the dependency was already added to a small function to improve readability.

Fixes #40 